### PR TITLE
create placeholder for purple blueprints

### DIFF
--- a/DS MP Speedrun Strats/4_purple/README.md
+++ b/DS MP Speedrun Strats/4_purple/README.md
@@ -1,0 +1,3 @@
+# Purple Science
+
+Needs more steel


### PR DESCRIPTION
This isn't really anything yet, but now a 4_purple folder appears, suggesting the possibility of future blueprints someday appearing there